### PR TITLE
Added a getTask method / modified TaskInstance schema

### DIFF
--- a/Meta/Schemas/TaskInstance.json
+++ b/Meta/Schemas/TaskInstance.json
@@ -1,35 +1,25 @@
 {
-    "task": { ... },
-    "task_id": "_Task1",
-    "chat_id": "_Chat1",
-    "steps_progress": [
+    "name": "Server Deploy",
+    "description": "Deploy new version of code to server",
+    "estimated_time": 180,
+    "steps": [
         {
-            "name": "name",
-            "description": "description",            
-            "state": "complete",
-            "completed_by": "_User1",
-            "completed_at": "TIME"
-        },
-        {
-            "name": "name",
-            "description": "description",
+            "name": "Check diff",
+            "details": "
+                Check the diff between the currently deployed version and the
+                version that you wish to deploy
+                    `$ git diff server/master HEAD`
+            ",
             "state": "in_progress",
-            "completed_by": null,
-            "completed_at": null
-        },
-        {
-            "name": "name",
-            "description": "description",
-            "state": "requires_signoff",
-            "completed_by": "_User2",
-            "completed_at": null
-        },
-        {
-            "name": "name",
-            "description": "description",
-            "state": "not_started",
-            "completed_by": null,
-            "completed_at": null
+            "completed_by": "_User4",
+            "completed_at": null,
+            "assignees": [
+                "_User1",
+                "_User2"
+            ],
+            "signoff": "_User3",
         }
-    ]
+    ],
+    "task_id": "_Task1",
+    "chat_id": "_Chat1"
 }

--- a/TaskHero/HomeViewController.swift
+++ b/TaskHero/HomeViewController.swift
@@ -11,16 +11,25 @@ import UIKit
 class HomeViewController: UIViewController {
     
     var tasks: [Task]?
-    var currentSelectedCellRowNum = -1
-    
+    var selectedCell = -1
     @IBOutlet weak var tableView: UITableView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         loadNavigationBar()
-        getDummyData()
         loadTableView()
+        loadTasks()
     }
+    
+    func loadTasks() {
+        ParseClient.sharedInstance.getAllTasks(sucess: {(tasks) -> () in
+            self.tasks = tasks
+            self.tableView.reloadData()
+        }, failure: {(error) -> () in
+            NSLog("Error: \(error)")
+        })
+    }
+    
     
     @IBAction func logoutButton(_ sender: UIBarButtonItem) {
         ParseClient.logout()
@@ -32,7 +41,7 @@ class HomeViewController: UIViewController {
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "HomeToTaskDetail" {
-            let task = tasks![currentSelectedCellRowNum]
+            let task = tasks![selectedCell]
             let taskDetailViewController = segue.destination as! TaskDetailViewController
             taskDetailViewController.task = task
         }
@@ -46,7 +55,6 @@ extension HomeViewController: UITableViewDelegate, UITableViewDataSource {
         tableView.dataSource = self
         tableView.estimatedRowHeight = 70
         tableView.rowHeight = UITableViewAutomaticDimension
-        tableView.reloadData()
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -58,7 +66,7 @@ extension HomeViewController: UITableViewDelegate, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return (tasks?.count)!
+        return tasks == nil ? 0 : (tasks?.count)!
     }
     
     func getDummyData() {
@@ -66,7 +74,7 @@ extension HomeViewController: UITableViewDelegate, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {        
-        currentSelectedCellRowNum = indexPath.row
+        selectedCell = indexPath.row
         tableView.deselectRow(at: indexPath, animated: true)
         performSegue(withIdentifier: "HomeToTaskDetail", sender: self)
     }

--- a/TaskHero/Step.swift
+++ b/TaskHero/Step.swift
@@ -13,5 +13,66 @@ class Step: NSObject {
     var details: String?
     var state: String?
     var assignees: [User]?
-    var signoffs: [User]?
+    var signoff: User?
+    var completedBy: User?
+    var completedAt: TimeInterval?
+    
+    override init() {
+        super.init()
+    }
+    
+    init(stepDictionary: [String: AnyObject]?) {
+        super.init()
+        
+        self.name = stepDictionary?["name"] as! String?
+        self.getAssignees(assignees: stepDictionary?["assignees"] as! [String])
+        
+        if let details = stepDictionary?["details"] as? String?  {
+            self.details = details
+        }
+        if let state = stepDictionary?["state"] as? String?  {
+            self.state = state
+        }
+        if let completedAt = stepDictionary?["completed_at"] {
+            self.completedAt = (completedAt as! TimeInterval)
+        }
+        if let completedBy = stepDictionary?["completed_by"] {
+            getCompletedBy(completedBy: (completedBy as! String))
+        }
+        if let signoff = stepDictionary?["signoff"]  {
+            getSignoff(signoff: (signoff as! String))
+        }
+    }
+    
+    private func getAssignees(assignees: [String]) {
+        for assignee in assignees {
+            ParseClient.sharedInstance.getUser(userId: assignee, success: { (user) -> () in
+                if self.assignees == nil {
+                    self.assignees = [user]
+                } else {
+                    self.assignees?.append(user)
+                }
+            }, failure: { error in
+                NSLog("Error getting users, error: \(error)")
+            })
+        }
+    }
+    
+    private func getSignoff(signoff: String) {
+        ParseClient.sharedInstance.getUser(userId: signoff, success: { (user) -> () in
+            self.signoff? = user
+        }, failure: { error in
+            NSLog("Error getting user, error: \(error)")
+        })
+    }
+    
+    private func getCompletedBy(completedBy: String) {
+        ParseClient.sharedInstance.getUser(userId: completedBy, success: { (user) -> () in
+            self.signoff? = user
+        }, failure: { error in
+            NSLog("Error getting user, error: \(error)")
+        })
+    }
+    
+    
 }

--- a/TaskHero/Task.swift
+++ b/TaskHero/Task.swift
@@ -7,11 +7,51 @@
 //
 
 import Foundation
+import Parse
 
 class Task: NSObject {
     var name: String?
     var details: String?
     var estimatedTime: TimeInterval?
     var steps: [Step]?
-    var author: User?
+    var taskId: String?
+    var chatId: String?
+    
+    override init() {
+        super.init()
+    }
+    
+    init(task: PFObject) {
+        super.init()
+    
+        self.name = task["name"] as? String
+        self.details = task["details"] as? String
+        self.getSteps(steps: (task["steps"] as? String)!)
+        
+        if let estimatedTime = task["estimated_time"] {
+            self.estimatedTime = estimatedTime as! TimeInterval
+        }
+        if let taskId = task["taskId"] {
+            self.taskId = taskId as! String
+        }
+        if let chatId = task["chatId"] {
+            self.chatId = chatId as! String
+        }
+    }
+
+    private func getSteps(steps: String) {
+        let data = steps.data(using: .utf8)
+        let stepsJson = try! JSONSerialization.jsonObject(with: data!, options: []) as! [Any]
+        for stepJson in stepsJson {
+            let stepDictionary = stepJson as! [String: AnyObject]
+            let step = Step(stepDictionary: stepDictionary)
+            if self.steps == nil {
+                self.steps = [step]
+            } else {
+                self.steps?.append(step)
+            }
+        }
+    }
+    
+    
 }

--- a/TaskHero/TaskDetailViewController.swift
+++ b/TaskHero/TaskDetailViewController.swift
@@ -30,7 +30,6 @@ class TaskDetailViewController: UIViewController {
  
         taskName.text = task?.name
         taskDescription.text = task?.details
-        estimatedTime.text = String(describing: (task?.estimatedTime)!)
         
         tableView.dataSource = self
         tableView.delegate = self


### PR DESCRIPTION
Hey guys, wanted to push some changes defining our structure.

I changed the TaskInstance schema which should simplify things a bit - instead of adding a separate meta structure associated with each step, I'm proposing we copy the Task, and then just add the new fields we need for the instance. We should still create a pointer to the original Task.

Doing this allows us to reuse the Task class for both uses now (template and instance) instead of breaking it out.

I added a getTasks which'll initialize the data from parse along with the steps.

The biggest TODOs:
* Create a taskInstance and save to Parse. @akishinagawa I think you'll be tackling this - look at the ParseClient createTask method for inspiration. You'll also want to initialize some values for the Task and Step and save it to the TaskInstance table / class. When you get this done, do push this change so I can work on modifying it.
* Chat
* Completing tasks
* Utilize pushes! I thinking at least three spots: when we create a new instance to all users that have at least a step, to the next list of assigned users on step completion, and when we complete a task.